### PR TITLE
Mark GRPC API Client as production ready

### DIFF
--- a/packages/grpc-api-client/README.md
+++ b/packages/grpc-api-client/README.md
@@ -1,8 +1,6 @@
 # GRPC API Client
 
-![Status](https://img.shields.io/badge/Project_status-Alpha-orange)
-
-The GRPC API Client is _not yet ready to be used in production applications_
+![Status](https://img.shields.io/badge/Project_status-Production-green)
 
 An API Client that satisfies the `xmtp-js` `ApiClient` interface, to be used in Node.js applications.
 


### PR DESCRIPTION
This has been ready for a while, and is used in production applications. I think the status is holding people back from deploying.