### PR TITLE
Export all the types

### DIFF
--- a/.changeset/fuzzy-swans-pretend.md
+++ b/.changeset/fuzzy-swans-pretend.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/frames-validator": patch
+---
+
+Export all the types

--- a/packages/frames-validator/src/index.ts
+++ b/packages/frames-validator/src/index.ts
@@ -3,6 +3,7 @@ import { Signature, SignedPublicKeyBundle } from "@xmtp/xmtp-js"
 
 import { sha256 } from "./crypto.js"
 import { FramePostPayload, FramePostUntrustedData } from "./types.js"
+export * from "./types.js"
 
 const { b64Decode } = fetcher
 


### PR DESCRIPTION
## Summary

With the switch to Rollup, I need to export the types from the package so I can use them in dependent libraries.