### PR TITLE
Add GRPC keepalives back

### DIFF
--- a/.changeset/weak-walls-cover.md
+++ b/.changeset/weak-walls-cover.md
@@ -1,0 +1,5 @@
+---
+"@xmtp/grpc-api-client": patch
+---
+
+Adjust GRPC keepalive settings

--- a/packages/grpc-api-client/src/GrpcApiClient.ts
+++ b/packages/grpc-api-client/src/GrpcApiClient.ts
@@ -57,9 +57,9 @@ export default class GrpcApiClient implements ApiClient {
     this.logger = pino({ name: "GrpcApiClient" })
     const grpcOptions = {
       "grpc.keepalive_timeout_ms": 1000 * 10, // 10 seconds
-      "grpc.keepalive_time_ms": 1000 * 15, // 15 seconds
+      "grpc.keepalive_time_ms": 1000 * 30, // 30 seconds
       "grpc.enable_retries": 1,
-      "grpc.keepalive_permit_without_calls": 1,
+      "grpc.keepalive_permit_without_calls": 0,
     }
     this.grpcClient = new MessageApiClient(
       new GrpcTransport({

--- a/packages/grpc-api-client/src/GrpcApiClient.ts
+++ b/packages/grpc-api-client/src/GrpcApiClient.ts
@@ -36,8 +36,8 @@ import {
 } from "./gen/message_api/v1/message_api.js"
 
 const API_URLS: { [k: string]: string } = {
-  dev: "dev.xmtp.network:5556",
-  production: "production.xmtp.network:5556",
+  dev: "grpc.dev.xmtp.network:443",
+  production: "grpc.production.xmtp.network:443",
   local: "localhost:5556",
 }
 
@@ -55,13 +55,16 @@ export default class GrpcApiClient implements ApiClient {
     this.apiUrl = apiUrl
     this.appVersion = appVersion
     this.logger = pino({ name: "GrpcApiClient" })
+    const grpcOptions = {
+      "grpc.keepalive_timeout_ms": 1000 * 10, // 10 seconds
+      "grpc.keepalive_time_ms": 1000 * 15, // 15 seconds
+      "grpc.enable_retries": 1,
+      "grpc.keepalive_permit_without_calls": 1,
+    }
     this.grpcClient = new MessageApiClient(
       new GrpcTransport({
         host: apiUrl,
-        clientOptions: {
-          "grpc.keepalive_time_ms": 1000 * 60 * 5, // 5 minutes
-          "grpc.enable_retries": 1,
-        },
+        clientOptions: grpcOptions,
         channelCredentials: isSecure
           ? credentials.createSsl()
           : credentials.createInsecure(),

--- a/packages/grpc-api-client/src/GrpcApiClient.ts
+++ b/packages/grpc-api-client/src/GrpcApiClient.ts
@@ -44,6 +44,13 @@ const API_URLS: { [k: string]: string } = {
 const SLEEP_TIME = 1000
 const MAX_RETRIES = 4
 
+const clientOptions = {
+  "grpc.keepalive_timeout_ms": 1000 * 10, // 10 seconds
+  "grpc.keepalive_time_ms": 1000 * 30, // 30 seconds
+  "grpc.enable_retries": 1,
+  "grpc.keepalive_permit_without_calls": 0,
+} as const
+
 export default class GrpcApiClient implements ApiClient {
   grpcClient: MessageApiClient
   private authCache?: AuthCache
@@ -55,16 +62,10 @@ export default class GrpcApiClient implements ApiClient {
     this.apiUrl = apiUrl
     this.appVersion = appVersion
     this.logger = pino({ name: "GrpcApiClient" })
-    const grpcOptions = {
-      "grpc.keepalive_timeout_ms": 1000 * 10, // 10 seconds
-      "grpc.keepalive_time_ms": 1000 * 30, // 30 seconds
-      "grpc.enable_retries": 1,
-      "grpc.keepalive_permit_without_calls": 0,
-    }
     this.grpcClient = new MessageApiClient(
       new GrpcTransport({
         host: apiUrl,
-        clientOptions: grpcOptions,
+        clientOptions,
         channelCredentials: isSecure
           ? credentials.createSsl()
           : credentials.createInsecure(),


### PR DESCRIPTION
## tl;dr

- Follow-up to https://github.com/xmtp/xmtp-node-go/pull/387.
- Will do some more testing locally with long-lives streams before merging