### PR TITLE
fix release

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10312,7 +10312,7 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.4.5#optional!builtin<compat/typescript>":
   version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=29ae49"
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
Installing from the package directly changes a checksum causing the release action to fail:
https://github.com/xmtp/xmtp-node-js-tools/actions/runs/9717583668/job/26823548033 